### PR TITLE
docs: コミュニティハブREADMEを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,164 @@
-# info
-A repository containing information about Tie
+# TieBase Community Hub
+
+<div align="center">
+  
+[![Discussions](https://img.shields.io/github/discussions/tiebase/info)](https://github.com/tiebase/info/discussions)
+[![Issues](https://img.shields.io/github/issues/tiebase/info)](https://github.com/tiebase/info/issues)
+[![License](https://img.shields.io/badge/license-see%20repositories-blue)](https://github.com/tiebase)
+
+**English** | [日本語](#日本語版)
+
+</div>
+
+## Welcome!
+
+This is the community hub for TieBase applications. Here you can:
+- 🐛 Report bugs and issues
+- 💡 Suggest new features and improvements
+- 💬 Participate in discussions about the product
+- 📚 Access documentation and guides
+- 🗺️ View the development roadmap
+
+## How to Participate
+
+### 1. Start with Discussions
+Before creating an issue, please start a discussion to:
+- Share your ideas and get feedback
+- Ask questions about the product
+- Propose improvements or new features
+
+👉 [Start a Discussion](https://github.com/tiebase/info/discussions)
+
+### 2. Report Bugs
+If you encounter a bug:
+1. Check existing issues to avoid duplicates
+2. Use our bug report template
+3. Provide as much detail as possible
+
+👉 [Report a Bug](https://github.com/tiebase/info/issues/new?template=bug_report.md)
+
+### 3. Request Features
+Have an idea for improvement?
+1. Start with a discussion in the Ideas category
+2. Once refined, we'll create an issue to track implementation
+
+👉 [Suggest a Feature](https://github.com/tiebase/info/discussions/categories/ideas)
+
+## Our Workflow
+
+```
+Discussion → Community Feedback → Consensus → Issue Creation → Implementation
+```
+
+Read more about our workflow in the [Discussion to Issue Guide](https://github.com/tiebase/info/discussions/7).
+
+## Important Links
+
+- 📖 [FAQ](https://github.com/tiebase/info/discussions/5)
+- 🗺️ [Product Roadmap](https://github.com/tiebase/info/discussions/6)
+- 🎯 [Milestones](https://github.com/tiebase/info/milestones)
+- 🏢 [Organization Profile](https://github.com/tiebase)
+
+## Community Guidelines
+
+- Be respectful and constructive
+- Search before creating new discussions/issues
+- Provide clear context and examples
+- Use appropriate templates and categories
+
+## Note on Contributions
+
+TieBase applications are **not open source**. While we welcome:
+- Bug reports
+- Feature suggestions
+- Documentation improvements
+- Community discussions
+
+We do not accept pull requests for application code. All development is handled internally by the TieBase team.
+
+---
+
+# 日本語版
+
+<div align="center">
+
+[![ディスカッション](https://img.shields.io/github/discussions/tiebase/info)](https://github.com/tiebase/info/discussions)
+[![イシュー](https://img.shields.io/github/issues/tiebase/info)](https://github.com/tiebase/info/issues)
+[![ライセンス](https://img.shields.io/badge/license-各リポジトリ参照-blue)](https://github.com/tiebase)
+
+[English](#tiebase-community-hub) | **日本語**
+
+</div>
+
+## ようこそ！
+
+ここはTieBaseアプリケーションのコミュニティハブです。以下のことができます：
+- 🐛 バグや問題の報告
+- 💡 新機能や改善の提案
+- 💬 プロダクトに関するディスカッションへの参加
+- 📚 ドキュメントとガイドへのアクセス
+- 🗺️ 開発ロードマップの確認
+
+## 参加方法
+
+### 1. ディスカッションから始める
+イシューを作成する前に、ディスカッションを始めてください：
+- アイデアを共有してフィードバックを得る
+- プロダクトについて質問する
+- 改善や新機能を提案する
+
+👉 [ディスカッションを開始](https://github.com/tiebase/info/discussions)
+
+### 2. バグを報告
+バグを発見した場合：
+1. 重複を避けるため既存のイシューを確認
+2. バグ報告テンプレートを使用
+3. できるだけ詳細な情報を提供
+
+👉 [バグを報告](https://github.com/tiebase/info/issues/new?template=bug_report.md)
+
+### 3. 機能をリクエスト
+改善のアイデアがありますか？
+1. Ideasカテゴリーでディスカッションを開始
+2. 洗練されたら、実装を追跡するためのイシューを作成します
+
+👉 [機能を提案](https://github.com/tiebase/info/discussions/categories/ideas)
+
+## ワークフロー
+
+```
+ディスカッション → コミュニティフィードバック → 合意形成 → イシュー作成 → 実装
+```
+
+ワークフローの詳細は[DiscussionからIssueへのガイド](https://github.com/tiebase/info/discussions/7)をご覧ください。
+
+## 重要なリンク
+
+- 📖 [よくある質問](https://github.com/tiebase/info/discussions/5)
+- 🗺️ [プロダクトロードマップ](https://github.com/tiebase/info/discussions/6)
+- 🎯 [マイルストーン](https://github.com/tiebase/info/milestones)
+- 🏢 [組織プロフィール](https://github.com/tiebase)
+
+## コミュニティガイドライン
+
+- 敬意を持って建設的に
+- 新規作成前に検索
+- 明確なコンテキストと例を提供
+- 適切なテンプレートとカテゴリーを使用
+
+## コントリビューションについて
+
+TieBaseアプリケーションは**オープンソースではありません**。以下は歓迎します：
+- バグ報告
+- 機能提案
+- ドキュメントの改善
+- コミュニティディスカッション
+
+アプリケーションコードへのプルリクエストは受け付けていません。すべての開発はTieBaseチームが内部で行います。
+
+---
+
+<div align="center">
+  <p><strong>Let's build better software together!</strong></p>
+  <p><strong>一緒により良いソフトウェアを作りましょう！</strong></p>
+</div>


### PR DESCRIPTION
## 変更内容
コミュニティハブとしてのREADMEを日英バイリンガルで作成しました。

## 追加内容
- プロジェクトの概要と目的
- 参加方法のガイド
- ワークフローの説明
- コミュニティガイドライン
- 重要なリンク集
- オープンソースではないことの明記